### PR TITLE
Fix Sake tasks not aligning the tasks description properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next version
 
+### Fixed
+- Right alignment when printing tasks https://github.com/xcodeswift/sake/pull/28 by @pepibumur.
 
 ## 0.2.0
 

--- a/Tests/SakefileDescriptionTests/SakeTests.swift
+++ b/Tests/SakefileDescriptionTests/SakeTests.swift
@@ -6,14 +6,17 @@ import XCTest
 final class SakeTests: XCTestCase {
     
     enum Task: String, CustomStringConvertible {
-        case a
-        case b
+        case a = "a"
+        case b = "b_name"
         var description: String {
-           return self.rawValue
+            switch self {
+            case .a: return "a description"
+            case .b: return "b description"
+            }
         }
     }
     
-    func test_run_runsEverythingInTheRightOrder() {
+    func test_runTask_runsEverythingInTheRightOrder() {
         var executionOutputs: [String] = []
         let subject = Sake<Task> {
             $0.task(.a, dependencies: [.b]) { (_) in
@@ -46,7 +49,20 @@ final class SakeTests: XCTestCase {
             "after_each",
             "after_all"
         ])
-        
+    }
+
+    func test_runTasks_printsTheCorrectString() {
+        var printed: String!
+        let subject = Sake<Task>(printer: { printed = $0 }) {
+            $0.task(.a, dependencies: [.b]) { (_) in }
+            $0.task(.b) { _ in }
+        }
+        subject.run(arguments: ["tasks"])
+        let expected = """
+b_name:     b description
+a:          a description
+"""
+        XCTAssertEqual(printed, expected)
     }
     
 }


### PR DESCRIPTION
Resolves https://github.com/xcodeswift/sake/issues/22

### Short description 📝
When tasks are printed with `sake tasks` the descriptions are not left-aligned.

### Solution 📦
Update the tasks function to calculate the space between the name and the description based on the task name length and the longest task name.

### Implementation 👩‍💻👨‍💻
- [x] Fix it!
- [x] Test it!

### GIF
![gif](https://media.giphy.com/media/xUA7aNvqMAqIwLChsQ/giphy.gif)
