### PR TITLE
Throw an error when trying to register the same task more than once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixed
 - Right alignment when printing tasks https://github.com/xcodeswift/sake/pull/28 by @pepibumur.
 
+### Added
+- Throw an error when trying to register the same task more than once https://github.com/xcodeswift/sake/pull/29 by @pepibumur.
+
 ## 0.2.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ enum Task: String, CustomStringConvertible {
 }
 
 Sake<Task> {
-  $0.task(.build) { (utils) in
+  try $0.task(.build) { (utils) in
     // Here is where you define your build task
   }
 }.run()

--- a/Sakefile.swift
+++ b/Sakefile.swift
@@ -56,10 +56,10 @@ func updateFormula(version: String, branch: String, utils: Utils) throws {
 }
 
 Sake<Task> {
-    $0.task(.documentation) { (utils) in
+    try $0.task(.documentation) { (utils) in
         try generateDocs(utils: utils)
     }
-    $0.task(.continuousIntegration) { utils in
+    try $0.task(.continuousIntegration) { utils in
         print("> Linting the project")
         try utils.shell.runAndPrint(bash: "swiftlint")
         print("> Building the project")
@@ -67,7 +67,7 @@ Sake<Task> {
         print("> Testing the project")
         try utils.shell.runAndPrint(bash: "swift test")
     }
-    $0.task(.release) { (utils) in
+    try $0.task(.release) { (utils) in
         if try utils.git.anyChanges() { throw "Commit all your changes before starting the release" }
         if try utils.git.branch() != "master" { throw "The release process should be initialized from master" }
         let nextVersion = try Version(utils.git.lastTag()).bumpingMinor()

--- a/Sources/SakeKit/GenerateSakefile.swift
+++ b/Sources/SakeKit/GenerateSakefile.swift
@@ -51,7 +51,7 @@ public class GenerateSakefile {
         }
         
         Sake<Task> {
-            $0.task(.build) { (utils) in
+            try $0.task(.build) { (utils) in
                 // Here is where you define your build task
             }
         }.run()

--- a/Sources/SakeKit/RunSakefile.swift
+++ b/Sources/SakeKit/RunSakefile.swift
@@ -89,14 +89,15 @@ public class RunSakefile {
 
         var arguments: [String] = []
         arguments += ["--driver-mode=swift"]
-        // arguments += ["-L", filedescriptionLibraryPath.parent().normalize().string]
-        // arguments += ["-I", filedescriptionLibraryPath.parent().normalize().string]
-        // arguments += ["-lSakefileDescription"]
-
+        
         if let utilsLibraryPath = utilsLibraryPath() {
             arguments += ["-L", utilsLibraryPath.parent().normalize().string]
             arguments += ["-I", utilsLibraryPath.parent().normalize().string]
             arguments += ["-lSakefileUtils"]
+        } else {
+            arguments += ["-L", filedescriptionLibraryPath.parent().normalize().string]
+            arguments += ["-I", filedescriptionLibraryPath.parent().normalize().string]
+            arguments += ["-lSakefileDescription"]
         }
         arguments += [sakefilePath.string]
         arguments += self.arguments

--- a/Sources/SakeKit/RunSakefile.swift
+++ b/Sources/SakeKit/RunSakefile.swift
@@ -4,32 +4,32 @@ import SwiftShell
 
 /// Runs the Sakefile.
 public class RunSakefile {
-    
+
     // MARK: - Attributes
-    
+
     /// Path where the Sakefile.swift file is.
     let path: String
-    
+
     /// Arguments to be passed.
     let arguments: [String]
-    
+
     /// Verbose
     let verbose: Bool
-    
+
     /// Run bash command.
     let runBashCommand: (String) throws -> ()
-    
+
     /// Returns the Sakefile.swift path if it exists in the given directory.
     let sakefilePath: (Path) -> Path?
-    
+
     /// Returns the file description library path.
     let fileDescriptionLibraryPath: () -> Path?
-    
+
     /// Returns the utils library path.
     let utilsLibraryPath: () -> Path?
-    
+
     // MARK: - Init
-    
+
     /// Default constructor.
     ///
     /// - Parameters:
@@ -47,7 +47,7 @@ public class RunSakefile {
                   utilsLibraryPath: { Runtime.utilsLibraryPath() },
                   runBashCommand: { try runAndPrint(bash: $0) })
     }
-    
+
     /// Default constructor.
     ///
     /// - Parameters:
@@ -73,9 +73,9 @@ public class RunSakefile {
         self.utilsLibraryPath = utilsLibraryPath
         self.runBashCommand = runBashCommand
     }
-    
+
     // MARK: - Public
-    
+
     /// Executes the Sakefile.swift
     ///
     /// - Throws: an error if the execution fails for any reason.
@@ -86,12 +86,12 @@ public class RunSakefile {
         guard let filedescriptionLibraryPath = fileDescriptionLibraryPath() else {
             throw "Couldn't find libSakefileDescription.dylib to link against to"
         }
-        
+
         var arguments: [String] = []
         arguments += ["--driver-mode=swift"]
-        arguments += ["-L", filedescriptionLibraryPath.parent().normalize().string]
-        arguments += ["-I", filedescriptionLibraryPath.parent().normalize().string]
-        arguments += ["-lSakefileDescription"]
+        // arguments += ["-L", filedescriptionLibraryPath.parent().normalize().string]
+        // arguments += ["-I", filedescriptionLibraryPath.parent().normalize().string]
+        // arguments += ["-lSakefileDescription"]
 
         if let utilsLibraryPath = utilsLibraryPath() {
             arguments += ["-L", utilsLibraryPath.parent().normalize().string]
@@ -110,9 +110,9 @@ public class RunSakefile {
             throw "Error processing your Sakefile.swift. Use --verbose to get more details about the problem."
         }
     }
-    
+
     // MARK: - Fileprivate
-    
+
     static func sakefilePath(path: Path) -> Path? {
         let sakefilePath = (path + "Sakefile.swift").normalize()
         if sakefilePath.exists {
@@ -120,5 +120,5 @@ public class RunSakefile {
         }
         return nil
     }
-    
+
 }

--- a/Sources/SakefileDescription/Sake.swift
+++ b/Sources/SakefileDescription/Sake.swift
@@ -10,12 +10,18 @@ public final class Sake<T: RawRepresentable & CustomStringConvertible> where T.R
 
     fileprivate let utils: Utils = Utils()
     fileprivate let tasks: Tasks<T> = Tasks<T>()
-    fileprivate let tasksInitializer: (Tasks<T>) -> Void
+    fileprivate let tasksInitializer: (Tasks<T>) throws -> Void
     fileprivate let printer: (String) -> Void
 
     public init(tasksInitializer: @escaping (Tasks<T>) throws -> Void) {
         self.tasksInitializer = tasksInitializer
         self.printer = { print($0) }
+    }
+
+    init(printer: @escaping (String) -> Void,
+         tasksInitializer: @escaping (Tasks<T>) throws -> Void) {
+        self.tasksInitializer = tasksInitializer
+        self.printer = printer
     }
 
     init(printer: @escaping (String) -> Void,
@@ -40,7 +46,8 @@ public extension Sake {
         do {
             try tasksInitializer(tasks)
         } catch {
-            print("> Error initializing tasks: \(error)")
+            printer("> Error initializing tasks: \(error)")
+            return
         }
         guard let argument = arguments.first else {
             printer("> Error: Missing argument")

--- a/Sources/SakefileDescription/Sake.swift
+++ b/Sources/SakefileDescription/Sake.swift
@@ -82,7 +82,7 @@ public extension Sake {
             .map({ task in
                 let spaces = (longestName + margin) - task.key.count
                 let space = String.init(repeating: " ", count: spaces)
-                return "\(task.key):\(space)\(task.value.description)"
+                return "\(task.key):\(space)\(task.value.type.description)"
             })
             .joined(separator: "\n"))
     }

--- a/Sources/SakefileDescription/Tasks.swift
+++ b/Sources/SakefileDescription/Tasks.swift
@@ -47,14 +47,20 @@ public final class Tasks<T: RawRepresentable & CustomStringConvertible> where T.
     ///   - description: task description.
     ///   - dependencies: task dependencies.
     ///   - action: task action.
-    public func task(_ type: T, dependencies: [T] = [], action: @escaping (Utils) throws -> Void) {
+    public func task(_ type: T, dependencies: [T] = [], action: @escaping (Utils) throws -> Void) throws {
+        if tasks[type.rawValue] != nil {
+            throw "Trying to register task \(type.rawValue) that is already registered"
+        }
         tasks[type.rawValue] = Task(description: type.description, dependencies: dependencies.map({$0.rawValue}), action: action)
     }
     
     /// Adds a new task.
     ///
     /// - Parameter task: task to be added.
-    public func task(_ type: T, task: Task) {
+    public func task(_ type: T, task: Task) throws {
+        if tasks[type.rawValue] != nil {
+            throw "Trying to register task \(type.rawValue) that is already registered"
+        }
         tasks[type.rawValue] = task
     }
     

--- a/Sources/SakefileDescription/Tasks.swift
+++ b/Sources/SakefileDescription/Tasks.swift
@@ -2,25 +2,25 @@ import Foundation
 
 // MARK: - Task
 
-public final class Task   {
-
-    /// Task description.
-    let description: String
+public final class Task<T: RawRepresentable & CustomStringConvertible> where T.RawValue == String   {
 
     /// Task dependencies (other tasks)
     let dependencies: [String]
 
     /// Task action closure.
     let action: (Utils) throws -> Void
+    
+    /// Task type
+    let type: T
 
     /// Initializes the task.
     ///
     /// - Parameters:
-    ///   - description: task description.
+    ///   - type: task type.
     ///   - dependencies: task dependencies.
     ///   - action: action closure.
-    init(description: String, dependencies: [String] = [], action: @escaping (Utils) throws -> Void) {
-        self.description = description
+    public init(type: T, dependencies: [String] = [], action: @escaping (Utils) throws -> Void) {
+        self.type = type
         self.dependencies = dependencies
         self.action = action
     }
@@ -32,7 +32,7 @@ public final class Task   {
 public final class Tasks<T: RawRepresentable & CustomStringConvertible> where T.RawValue == String {
     
     /// Tasks.
-    var tasks: [String: Task] = [:]
+    var tasks: [String: Task<T>] = [:]
     
     /// Hooks
     var beforeAll: [(Utils) -> Void] = []
@@ -51,17 +51,19 @@ public final class Tasks<T: RawRepresentable & CustomStringConvertible> where T.
         if tasks[type.rawValue] != nil {
             throw "Trying to register task \(type.rawValue) that is already registered"
         }
-        tasks[type.rawValue] = Task(description: type.description, dependencies: dependencies.map({$0.rawValue}), action: action)
+        tasks[type.rawValue] = Task(type: type,
+                                    dependencies: dependencies.map({$0.rawValue}),
+                                    action: action)
     }
     
     /// Adds a new task.
     ///
     /// - Parameter task: task to be added.
-    public func task(_ type: T, task: Task) throws {
-        if tasks[type.rawValue] != nil {
-            throw "Trying to register task \(type.rawValue) that is already registered"
+    public func task(task: Task<T>) throws {
+        if tasks[task.type.rawValue] != nil {
+            throw "Trying to register task \(task.type.rawValue) that is already registered"
         }
-        tasks[type.rawValue] = task
+        tasks[task.type.rawValue] = task
     }
     
     /// Adds a before all hook.

--- a/Tests/SakeKitTests/RunSakefileTests.swift
+++ b/Tests/SakeKitTests/RunSakefileTests.swift
@@ -25,7 +25,7 @@ final class RunSakefileTests: XCTestCase {
     
     func test_execute_runsTheRightCommand() {
         print(runCommand)
-        XCTAssertEqual(runCommand, "exec 2>/dev/null; swiftc --driver-mode=swift -L /libraries -I /libraries -lSakefileDescription -L /utils -I /utils -lSakefileUtils /project/Sakefile.swift tasks build")
+        XCTAssertEqual(runCommand, "exec 2>/dev/null; swiftc --driver-mode=swift -L /utils -I /utils -lSakefileUtils /project/Sakefile.swift tasks build")
     }
     
     

--- a/Tests/SakefileDescriptionTests/SakeTests.swift
+++ b/Tests/SakefileDescriptionTests/SakeTests.swift
@@ -19,10 +19,10 @@ final class SakeTests: XCTestCase {
     func test_runTask_runsEverythingInTheRightOrder() {
         var executionOutputs: [String] = []
         let subject = Sake<Task> {
-            $0.task(.a, dependencies: [.b]) { (_) in
+            try $0.task(.a, dependencies: [.b]) { (_) in
                 executionOutputs.append("a")
             }
-            $0.task(.b) { (_) in
+            try $0.task(.b) { (_) in
                 executionOutputs.append("b")
             }
             $0.beforeEach { (_) in

--- a/Tests/SakefileDescriptionTests/SakeTests.swift
+++ b/Tests/SakefileDescriptionTests/SakeTests.swift
@@ -54,8 +54,8 @@ final class SakeTests: XCTestCase {
     func test_runTasks_printsTheCorrectString() {
         var printed: String!
         let subject = Sake<Task>(printer: { printed = $0 }) {
-            $0.task(.a, dependencies: [.b]) { (_) in }
-            $0.task(.b) { _ in }
+            try $0.task(.a, dependencies: [.b]) { (_) in }
+            try $0.task(.b) { _ in }
         }
         subject.run(arguments: ["tasks"])
         let expected = """

--- a/Tests/SakefileDescriptionTests/TasksTests.swift
+++ b/Tests/SakefileDescriptionTests/TasksTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import XCTest
+
+@testable import SakefileDescription
+
+final class TasksTests: XCTestCase {
+    
+    enum Task: String, CustomStringConvertible {
+        case a
+        case b
+        var description: String {
+            return self.rawValue
+        }
+    }
+    
+    func test_taskWithClosure_shouldPrintAnError_whenTheTaskIsAlreadyRegistered() {
+        var printed: String!
+        let subject = Sake<Task>(printer: { printed = $0 } ) {
+            try $0.task(.a) { (_) in }
+            try $0.task(.a) { (_) in }
+        }
+        subject.run(arguments: [])
+        XCTAssertEqual(printed, "> Error initializing tasks: Trying to register task a that is already registered")
+    }
+    
+    func test_taskWithTask_shouldThrow_whenTheTaskIsAlreadyRegistered() {
+        var printed: String!
+        let task = SakefileDescription.Task<Task>(type: .a, action: { _ in })
+        let subject = Sake<Task>(printer: { printed = $0 } ) {
+            try $0.task(task: task)
+            try $0.task(task: task)
+        }
+        subject.run(arguments: [])
+        XCTAssertEqual(printed, "> Error initializing tasks: Trying to register task a that is already registered")
+    }
+    
+}


### PR DESCRIPTION
Resolves https://github.com/xcodeswift/sake/issues/21

### Short description 📝
Before this fix, it was possible to register the same task more than once. The last one always overrode the previously registered.

### Solution 📦
If the developer tries to do that, Sake will throw an error when the developer tries to run the tasks from the console.

### Implementation 👩‍💻👨‍💻
- [x] Make `Task` initializer public.
- [x] Make `Task` generic.
- [x] Throw an error if that happens.
- [x] Test it.

### GIF
![gif](https://media.giphy.com/media/JJR2n3I7vVisE/giphy.gif)
