### PR TITLE
Auto correct sake task name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Added
 - Throw an error when trying to register the same task more than once https://github.com/xcodeswift/sake/pull/29 by @pepibumur.
+- It suggests an alternative task name when the user tries to execute a specific task and he misspells the task name https://github.com/xcodeswift/sake/pull/25 by @Juanpe.
 
 ## 0.2.0
 

--- a/Sources/SakefileDescription/Sake.swift
+++ b/Sources/SakefileDescription/Sake.swift
@@ -95,12 +95,19 @@ public extension Sake {
         printer(alertMessage)
     }
     
+    /// Find a possible alternative task name. How it work:
+    /// 1) Create an array with tuples '(task, distance)', calculating the distance between input task name and the available tasks.
+    /// 2) Filter tasks without occurrences (ex: "ci", distance = 2, doesn't have occurrences).
+    /// 3) Obtain the task with minimum distance.
+    ///
+    /// - Parameter task: the task name written by the user
+    /// - Returns: alternative task name if exist
     fileprivate func findSuggestionTaskName(for task: String) -> String? {
         let taskWithDistance = self.tasks.tasks.keys
-            .map { ($0, $0.levenshteinDistance(task)) }
-            .filter { $0.0.count != $0.1 }
-            .min { $0.1 < $1.1 }
-        return taskWithDistance?.0
+            .map { (taskName: $0, distance: $0.levenshteinDistance(task)) }
+            .filter { $0.taskName.count != $0.distance }
+            .min { $0.distance < $1.distance }
+        return taskWithDistance?.taskName
     }
 
     fileprivate func runTaskAndDependencies(task taskName: String) throws {

--- a/Sources/SakefileDescription/Sake.swift
+++ b/Sources/SakefileDescription/Sake.swift
@@ -88,9 +88,9 @@ public extension Sake {
     }
     
     fileprivate func printWarningTaskNotFound(_ task: String) {
-        var alertMessage = "> [!] Could not find task '\(task)'. "
+        var alertMessage = "> [!] Could not find task '\(task)'"
         if let suggestedTaskName = findSuggestionTaskName(for: task) {
-            alertMessage += "Maybe did you mean '\(suggestedTaskName)'?"
+            alertMessage += ". Maybe did you mean '\(suggestedTaskName)'?"
         }
         printer(alertMessage)
     }

--- a/Sources/SakefileDescription/String+Extras.swift
+++ b/Sources/SakefileDescription/String+Extras.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension String {
+    
+    func levenshteinDistance(_ string: String) -> Int {
+        let empty = Array<Int>(repeating:0, count: self.count)
+        var last = [Int](0...self.count)
+        
+        for (i, testLetter) in string.enumerated() {
+            var cur = [i + 1] + empty
+            for (j, keyLetter) in self.enumerated() {
+                cur[j + 1] = testLetter == keyLetter ? last[j] : Swift.min(last[j], last[j + 1], cur[j]) + 1
+            }
+            last = cur
+        }
+        return last.last!
+    }
+}

--- a/Tests/SakefileDescriptionTests/SakeTests.swift
+++ b/Tests/SakefileDescriptionTests/SakeTests.swift
@@ -65,4 +65,14 @@ a:          a description
         XCTAssertEqual(printed, expected)
     }
     
+    func test_runWrongTask_printSuggestedTaskName() {
+        var printed: String!
+        let subject = Sake<Task>(printer: { printed = $0 }) {
+            try $0.task(.a, dependencies: [.b]) { (_) in }
+            try $0.task(.b) { _ in }
+        }
+        subject.run(arguments: ["task", "_"])
+        let expected = "> [!] Could not find task '_'. Maybe did you mean 'b_name'?"
+        XCTAssertEqual(printed, expected)
+    }
 }


### PR DESCRIPTION
Resolves https://github.com/xcodeswift/sake/issues/25

### Solution 📦
When user tries to execute a specific task and we can not find it. We apply the Levenshtein algorithm to the available tasks to find an alternative task name. Then, the users get feedback about what it is happening.

_Example:_
```bash
> sake tasks
docs:        Generates the project documentation
ci:          Runs the the operations that are executed on CI
release:     Releases a new version of the Sake
```
```bash
> sake task w
> [!] Could not find task 'w'
```
```bash
> sake task relaese
> [!] Could not find task 'relaese'. Maybe did you mean 'release'?
```

### Implementation 👩‍💻👨‍💻
- [x] Implement Levenshtein algorithm
- [x] Apply the algorithm to suggest an alternative task name
- [x] Create unit test
- [x] Update CHANGELOG file

### GIF
![gif](https://media.giphy.com/media/105LLpMfSLWpDa/giphy.gif)
