### PR TITLE
Remove the need for utils param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next version
 
+### Changed
+- removed the need for a `utils` instance that gets passed around. Use `Utils` instead https://github.com/xcodeswift/sake/pull/41 by @yonaskolb.
+
 ### Fixed
 - Right alignment when printing tasks https://github.com/xcodeswift/sake/pull/28 by @pepibumur.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ enum Task: String, CustomStringConvertible {
 }
 
 Sake<Task> {
-  try $0.task(.build) { (utils) in
+  try $0.task(.build) {
     // Here is where you define your build task
   }
 }.run()

--- a/Sources/SakeKit/GenerateSakefile.swift
+++ b/Sources/SakeKit/GenerateSakefile.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Generates a base Sakefile.swift
 public class GenerateSakefile {
-    
+
     // MARK: - Attributes
 
     /// Path to the folder where the Sakefile.swift will be generated.
@@ -10,18 +10,18 @@ public class GenerateSakefile {
 
     /// File manager.
     fileprivate let fileManager: FileManager = .default
-    
+
     // MARK: - Init
-    
+
     /// Initializes the command that generates a base Sakefile.swift
     ///
     /// - Parameter path: path to the folder where the Sakefile.swift will be generated.
     public init(path: String) {
         self.path = path
     }
-    
+
     // MARK: - Public
-    
+
     /// Generates the base Sakefile.swift.
     ///
     /// - Throws: an error if the generation fails.
@@ -34,12 +34,12 @@ public class GenerateSakefile {
             .write(to: sakefilePath, atomically: true, encoding: .utf8)
         print("Sakefile.swift generated")
     }
-    
+
     static func defaultContent() -> String {
         return """
         import SakefileDescription
         import SakefileUtils
-        
+
         enum Task: String, CustomStringConvertible {
             case build
             var description: String {
@@ -49,13 +49,13 @@ public class GenerateSakefile {
                 }
             }
         }
-        
+
         Sake<Task> {
-            try $0.task(.build) { (utils) in
+            try $0.task(.build) {
                 // Here is where you define your build task
             }
         }.run()
         """
     }
-    
+
 }

--- a/Sources/SakefileDescription/Sake.swift
+++ b/Sources/SakefileDescription/Sake.swift
@@ -2,13 +2,13 @@ import Foundation
 
 // MARK: - Utils
 
-public class Utils {}
+// enum so it's not initializable
+public enum Utils {}
 
 // MARK: - Sake
 
 public final class Sake<T: RawRepresentable & CustomStringConvertible> where T.RawValue == String {
 
-    fileprivate let utils: Utils = Utils()
     fileprivate let tasks: Tasks<T> = Tasks<T>()
     fileprivate let tasksInitializer: (Tasks<T>) throws -> Void
     fileprivate let printer: (String) -> Void
@@ -115,8 +115,8 @@ public extension Sake {
             printWarningTaskNotFound(taskName)
             return
         }
-        tasks.beforeAll.forEach({ $0(utils) })
-        defer { tasks.afterAll.forEach({ $0(utils) }) }
+        tasks.beforeAll.forEach { $0() }
+        defer { tasks.afterAll.forEach { $0() } }
         try task.dependencies.forEach { try runTask(task: $0) }
         try runTask(task: taskName)
     }
@@ -127,9 +127,9 @@ public extension Sake {
             return
         }
         printer("> Running \"\(task.key)\"")
-        tasks.beforeEach.forEach({$0(utils)})
-        try task.value.action(self.utils)
-        tasks.afterEach.forEach({$0(utils)})
+        tasks.beforeEach.forEach { $0() }
+        try task.value.action()
+        tasks.afterEach.forEach { $0() }
     }
 
 }

--- a/Sources/SakefileDescription/Sake.swift
+++ b/Sources/SakefileDescription/Sake.swift
@@ -1,10 +1,5 @@
 import Foundation
 
-// MARK: - Utils
-
-// enum so it's not initializable
-public enum Utils {}
-
 // MARK: - Sake
 
 public final class Sake<T: RawRepresentable & CustomStringConvertible> where T.RawValue == String {

--- a/Sources/SakefileDescription/Tasks.swift
+++ b/Sources/SakefileDescription/Tasks.swift
@@ -8,7 +8,7 @@ public final class Task<T: RawRepresentable & CustomStringConvertible> where T.R
     let dependencies: [String]
 
     /// Task action closure.
-    let action: (Utils) throws -> Void
+    let action: () throws -> Void
     
     /// Task type
     let type: T
@@ -19,7 +19,7 @@ public final class Task<T: RawRepresentable & CustomStringConvertible> where T.R
     ///   - type: task type.
     ///   - dependencies: task dependencies.
     ///   - action: action closure.
-    public init(type: T, dependencies: [String] = [], action: @escaping (Utils) throws -> Void) {
+    public init(type: T, dependencies: [String] = [], action: @escaping () throws -> Void) {
         self.type = type
         self.dependencies = dependencies
         self.action = action
@@ -35,10 +35,10 @@ public final class Tasks<T: RawRepresentable & CustomStringConvertible> where T.
     var tasks: [String: Task<T>] = [:]
     
     /// Hooks
-    var beforeAll: [(Utils) -> Void] = []
-    var beforeEach: [(Utils) -> Void] = []
-    var afterAll: [(Utils) -> Void] = []
-    var afterEach: [(Utils) -> Void] = []
+    var beforeAll: [() -> Void] = []
+    var beforeEach: [() -> Void] = []
+    var afterAll: [() -> Void] = []
+    var afterEach: [() -> Void] = []
 
     /// Adds a new task.
     ///
@@ -47,7 +47,7 @@ public final class Tasks<T: RawRepresentable & CustomStringConvertible> where T.
     ///   - description: task description.
     ///   - dependencies: task dependencies.
     ///   - action: task action.
-    public func task(_ type: T, dependencies: [T] = [], action: @escaping (Utils) throws -> Void) throws {
+    public func task(_ type: T, dependencies: [T] = [], action: @escaping () throws -> Void) throws {
         if tasks[type.rawValue] != nil {
             throw "Trying to register task \(type.rawValue) that is already registered"
         }
@@ -69,28 +69,28 @@ public final class Tasks<T: RawRepresentable & CustomStringConvertible> where T.
     /// Adds a before all hook.
     ///
     /// - Parameter closure: closure that will be executed before all the tasks.
-    public func beforeAll(_ closure: @escaping (Utils) -> Void) {
+    public func beforeAll(_ closure: @escaping () -> Void) {
         beforeAll.append(closure)
     }
     
     /// Adds a before each hook.
     ///
     /// - Parameter closure: closure that will be executed before each task.
-    public func beforeEach(_ closure: @escaping (Utils) -> Void) {
+    public func beforeEach(_ closure: @escaping () -> Void) {
         beforeEach.append(closure)
     }
     
     /// Adds an after all hook.
     ///
     /// - Parameter closure: closure that will be executed after all the tasks.
-    public func afterAll(_ closure: @escaping (Utils) -> Void) {
+    public func afterAll(_ closure: @escaping () -> Void) {
         afterAll.append(closure)
     }
     
     /// Adds an after each hook.
     ///
     /// - Parameter closure: closure that will be executed after each task.
-    public func afterEach(_ closure: @escaping (Utils) -> Void) {
+    public func afterEach(_ closure: @escaping () -> Void) {
         afterEach.append(closure)
     }
     

--- a/Sources/SakefileUtils/Utils.swift
+++ b/Sources/SakefileUtils/Utils.swift
@@ -7,9 +7,11 @@ fileprivate var httpInstance: HTTP!
 fileprivate var shellInstance: Shell!
 fileprivate var gitInstance: Git!
 
-// MARK: - Utils Extension
+// MARK: - Utils
 
-public extension Utils {
+// Utils is an enum so it's not initializable
+/// a bunch of useful Utilities
+public enum Utils {
 
     /// HTTP
     public static var http = HTTP()

--- a/Sources/SakefileUtils/Utils.swift
+++ b/Sources/SakefileUtils/Utils.swift
@@ -12,26 +12,11 @@ fileprivate var gitInstance: Git!
 public extension Utils {
 
     /// HTTP
-    public var http: HTTP {
-        if httpInstance == nil {
-            httpInstance = HTTP()
-        }
-        return httpInstance
-    }
+    public static var http = HTTP()
     
     /// Shell
-    public var shell: Shell {
-        if shellInstance == nil {
-            shellInstance = Shell()
-        }
-        return shellInstance
-    }
-    
+    public static var shell = Shell()
+
     /// Git
-    public var git: Git {
-        if gitInstance == nil {
-            gitInstance = Git(shell: shell)
-        }
-        return gitInstance
-    }
+    public static let git = Git(shell: shell)
 }

--- a/Tests/SakefileDescriptionTests/SakeTests.swift
+++ b/Tests/SakefileDescriptionTests/SakeTests.swift
@@ -19,22 +19,22 @@ final class SakeTests: XCTestCase {
     func test_runTask_runsEverythingInTheRightOrder() {
         var executionOutputs: [String] = []
         let subject = Sake<Task> {
-            try $0.task(.a, dependencies: [.b]) { (_) in
+            try $0.task(.a, dependencies: [.b]) {
                 executionOutputs.append("a")
             }
-            try $0.task(.b) { (_) in
+            try $0.task(.b) {
                 executionOutputs.append("b")
             }
-            $0.beforeEach { (_) in
+            $0.beforeEach {
                 executionOutputs.append("before_each")
             }
-            $0.beforeAll { (_) in
+            $0.beforeAll {
                 executionOutputs.append("before_all")
             }
-            $0.afterEach { (_) in
+            $0.afterEach {
                 executionOutputs.append("after_each")
             }
-            $0.afterAll { (_) in
+            $0.afterAll {
                 executionOutputs.append("after_all")
             }
         }
@@ -54,8 +54,8 @@ final class SakeTests: XCTestCase {
     func test_runTasks_printsTheCorrectString() {
         var printed: String!
         let subject = Sake<Task>(printer: { printed = $0 }) {
-            try $0.task(.a, dependencies: [.b]) { (_) in }
-            try $0.task(.b) { _ in }
+            try $0.task(.a, dependencies: [.b]) { }
+            try $0.task(.b) { }
         }
         subject.run(arguments: ["tasks"])
         let expected = """
@@ -68,8 +68,8 @@ a:          a description
     func test_runWrongTask_printSuggestedTaskName() {
         var printed: String!
         let subject = Sake<Task>(printer: { printed = $0 }) {
-            try $0.task(.a, dependencies: [.b]) { (_) in }
-            try $0.task(.b) { _ in }
+            try $0.task(.a, dependencies: [.b]) { }
+            try $0.task(.b) {  }
         }
         subject.run(arguments: ["task", "_"])
         let expected = "> [!] Could not find task '_'. Maybe did you mean 'b_name'?"

--- a/Tests/SakefileDescriptionTests/TasksTests.swift
+++ b/Tests/SakefileDescriptionTests/TasksTests.swift
@@ -16,8 +16,8 @@ final class TasksTests: XCTestCase {
     func test_taskWithClosure_shouldPrintAnError_whenTheTaskIsAlreadyRegistered() {
         var printed: String!
         let subject = Sake<Task>(printer: { printed = $0 } ) {
-            try $0.task(.a) { (_) in }
-            try $0.task(.a) { (_) in }
+            try $0.task(.a) { }
+            try $0.task(.a) { }
         }
         subject.run(arguments: [])
         XCTAssertEqual(printed, "> Error initializing tasks: Trying to register task a that is already registered")
@@ -25,7 +25,7 @@ final class TasksTests: XCTestCase {
     
     func test_taskWithTask_shouldThrow_whenTheTaskIsAlreadyRegistered() {
         var printed: String!
-        let task = SakefileDescription.Task<Task>(type: .a, action: { _ in })
+        let task = SakefileDescription.Task<Task>(type: .a, action: { })
         let subject = Sake<Task>(printer: { printed = $0 } ) {
             try $0.task(task: task)
             try $0.task(task: task)


### PR DESCRIPTION
### Short description 📝
Replaces `utils` instance with static `Utils`.

### Solution 📦
This remove the instance of `utils` that is passed into every task and then must be passed anywhere else it needs to be used. There was no state stored in this type, so it can become a simple container type with static classes for the utils themselves. The updated SakeFile within this PR is a good example of the changes.
This is a breaking change as it removes all the `utils` parameters and changes `util.` to `Util.`

### Implementation 👩‍💻👨‍💻
- [x] remove the `utils` instance variable from `Sake`
- [x] remove the passing of `utils` around the system
- [x] make Utils simple name spacing type and make utility classes static properties on that type
- [x] update the docs
- [x] update the `SakeFile` used within this project (it's a good example of the changes)