### PR TITLE
Clean up extra linebreaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Right alignment when printing tasks https://github.com/xcodeswift/sake/pull/28 by @pepibumur.
 - Xcode not being able to run Sake because there was no `main.swift` file https://github.com/xcodeswift/sake/pull/36 by @pepibumur.
 - Update project dependencies to their latest versions. PathKit to 0.9.0, xcproj to 1.7.0 and Commander to 0.8.0
+- Clean up extra linebreaks https://github.com/xcodeswift/sake/pull/46 by @pepibumur.
 
 ### Removed
 - The need to call `run()` to execute the tasks https://github.com/xcodeswift/sake/pull/36 by @pepibumur.

--- a/Sakefile.swift
+++ b/Sakefile.swift
@@ -52,5 +52,8 @@ Sake(tasks: [
         let branch = "release/\(nextVersion.string)"
         try createVersion(version: nextVersion.string, branch: branch)
         try updateFormula(version: nextVersion.string, branch: branch)
+    },
+    Task("test", description: "Runs tests") {
+        try Utils.shell.runAndPrint(bash: "swift test")
     }]
 )

--- a/Sources/SakeKit/RunSakefile.swift
+++ b/Sources/SakeKit/RunSakefile.swift
@@ -82,7 +82,7 @@ public class RunSakefile {
 
         var arguments: [String] = []
         arguments += ["--driver-mode=swift"]
-        
+        arguments += ["-suppress-warnings"]
         arguments += ["-L", filedescriptionLibraryPath.parent().normalize().string]
         arguments += ["-I", filedescriptionLibraryPath.parent().normalize().string]
         arguments += ["-lSakefileDescription"]

--- a/Sources/SakefileDescription/Shell.swift
+++ b/Sources/SakefileDescription/Shell.swift
@@ -36,10 +36,7 @@ public protocol Shelling {
 /// - Returns: cleaned output.
 func clean(output: String) -> String {
     var output = output
-    let firstnewline = output.index(of: "\n")
-    if firstnewline == nil || output.index(after: firstnewline!) == output.endIndex {
-        output = output.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
+    output = output.trimmingCharacters(in: .whitespacesAndNewlines)
     return output
 }
 

--- a/Tests/SakeKitTests/RunSakefileTests.swift
+++ b/Tests/SakeKitTests/RunSakefileTests.swift
@@ -24,7 +24,7 @@ final class RunSakefileTests: XCTestCase {
     
     func test_execute_runsTheRightCommand() {
         print(runCommand)
-        XCTAssertEqual(runCommand, "exec 2>/dev/null; swiftc --driver-mode=swift -L /libraries -I /libraries -lSakefileDescription /project/Sakefile.swift tasks build")
+        XCTAssertEqual(runCommand, "exec 2>/dev/null; swiftc --driver-mode=swift -suppress-warnings -L /libraries -I /libraries -lSakefileDescription /project/Sakefile.swift tasks build")
     }
     
     


### PR DESCRIPTION
Resolves https://github.com/xcodeswift/sake/issues/15

### Short description 📝
When `Shell` printed out the output from the running processes there were extra line breaks. As a result, the output didn't match the output you got running the command directly from the console.

### Solution 📦
I've updated the cleanup function to trim the linebreaks in every line that is printed.

### GIF
![gif](https://media.giphy.com/media/xUPGcChZRE8p2djeiQ/giphy.gif)
