### PR TITLE
Add version command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next version
 
+### Added
+- Version command https://github.com/xcodeswift/sake/pull/54 - by @pepibumur.
+
 ## 0.5.0
 
 ### Added

--- a/Sakefile.swift
+++ b/Sakefile.swift
@@ -6,17 +6,29 @@ func publishWebsite() throws {
     try Utils.shell.runAndPrint(bash: "bundle exec jazzy --clean --sdk macosx --output api --xcodebuild-arguments -scheme,sake,-project,sake.xcodeproj --skip-undocumented")
     try Utils.shell.runAndPrint(bash: "cd website; yarn build;")
     try Utils.shell.runAndPrint(bash: "cd website; USE_SSH=true yarn run publish-gh-pages")
- }
+}
 
- func serveWebsite() throws {
-     try Utils.shell.runAndPrint(bash: "cd website; yarn start;")
- }
+func serveWebsite() throws {
+    try Utils.shell.runAndPrint(bash: "cd website; yarn start;")
+}
+
+func updateVersionSwift(version: String) throws {
+    let versionContent = """
+    import Foundation
+    public let version = "\(version)"
+    """
+    let currentDirectoryPath = FileManager.default.currentDirectoryPath
+    let versionURL = URL(fileURLWithPath: currentDirectoryPath)
+        .appendingPathComponent("Sources/SakeKit/Version.swift")
+    try versionContent.write(to: versionURL, atomically: true, encoding: .utf8)
+}
 
 func createVersion(version: String, branch: String) throws {
     print("> Building the project")
     try Utils.shell.runAndPrint(bash: "swift build")
     print("> Generating docs")
     try publishWebsite()
+    try updateVersionSwift(version: version)
     try Utils.git.addAll()
     try Utils.git.commitAll(message: "[\(branch)] Bump version")
     try Utils.git.tag(version)

--- a/Sources/SakeKit/Version.swift
+++ b/Sources/SakeKit/Version.swift
@@ -1,3 +1,3 @@
 import Foundation
 
-public let version = "0.6.0"
+public let version = "0.5.0"

--- a/Sources/SakeKit/Version.swift
+++ b/Sources/SakeKit/Version.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+public let version = "0.6.0"

--- a/Sources/sake/main.swift
+++ b/Sources/sake/main.swift
@@ -24,8 +24,12 @@ Group {
     let tasksCommand = command(Option("path", default: "", flag: "p", description: "Sakefile.swift path")) { (path) in
         try RunSakefile(path: directoryFrom(path: path), arguments: ["tasks"]).execute()
     }
+    let versionCommand = command() {
+        print(version)
+    }
     $0.addCommand("init", "initializes a Sakefile in the current directory", initCommand)
     $0.addCommand("task", "runs the task passed", taskCommand)
     $0.addCommand("tasks", "lists all the available tasks", tasksCommand)
     $0.addCommand("generate-xcodeproj", "generates an Xcode project to edit the Sakefile", generateXcodeProjCommand)
+    $0.addCommand("version", "prints the version of Sake", versionCommand)
 }.run()


### PR DESCRIPTION
Resolves https://github.com/xcodeswift/sake/issues/49

### Short description 📝
Add a command that prints the Sake version.

### Implementation 👩‍💻👨‍💻
- [x] Add `Versions.swift` file.
- [x] Update the release process to bump the version in that file.
- [x] Add the command to the `main.swift`.

### GIF
![gif](https://media.giphy.com/media/bol5KfQhYguZy/giphy.gif)
